### PR TITLE
Tidy time [Delivers #84489594, 84489610, 86647520, 86646136] [Finishes #84487538]

### DIFF
--- a/app/assets/stylesheets/shared.scss
+++ b/app/assets/stylesheets/shared.scss
@@ -63,6 +63,9 @@ nav {
 	}
 }
 
+.highlighted_text {
+	color: $red;
+}
 .main article {
 	margin: 5em 6em;
 	height: 100%;

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -29,7 +29,7 @@ class UsersController < ApplicationController
 
     if @user.update(user_params)
       flash[:notice] = "Update Successful!"
-      redirect_to users_path
+      redirect_to user_path(@user)
     else
       flash[:error] = "Update Failed"
       redirect_to :back

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -34,7 +34,7 @@ class User < ActiveRecord::Base
 
   def good_to_borrow?
     #organization-specific borrowing rules
-    self.name && (self.email || self.phone) && !self.do_not_lend && self.loans.active.count < 5
+    self.name && (self.email || self.phone) && self.identification && !self.do_not_lend && self.loans.active.count < 5
   end
 
   def pref_name

--- a/app/views/books/_form.html.erb
+++ b/app/views/books/_form.html.erb
@@ -2,16 +2,16 @@
 <% disabled = false if admin_user? %>
 <%= form_for @book do |f| %>
     <fieldset>
-    	<%= f.label :title %> 
+    	<%= f.label :title %>
     	<%= f.text_field :title, disabled: disabled %>
     </fieldset>
     <fieldset>
-    	<%= f.label :genre %> 
-    	<%= f.select :genre_id, Genre.all.collect { |n| [n.name, n.id] }, {}, multiple: false, class: "chosen-select" %>
+    	<%= f.label :genre %>
+    	<%= f.select :genre_id, Genre.all.collect { |n| [n.name, n.id] }, {}, multiple: false, class: "chosen-select", disabled: disabled %>
     </fieldset>
     <fieldset>
     	<%= f.label :author %>
-    	<%= f.select :author_ids, Author.all.collect { |a| [a.name, a.id] }, {}, multiple: true, class: "chosen-select" %>
+    	<%= f.select :author_ids, Author.all.collect { |a| [a.name, a.id] }, {}, multiple: true, class: "chosen-select", disabled: disabled %>
     </fieldset>
     <fieldset>
     	<%= f.label :keyword %>

--- a/app/views/books/show.html.erb
+++ b/app/views/books/show.html.erb
@@ -1,10 +1,10 @@
 <h2>Book: <%= @book.title %></h2>
 <h3> <%= @book.available ? "#{@book.count - @book.loans.active.count} available for checkout" : "unavailable for checkout" %> </h3>
+  <% if librarian_user? %>
+    <%=  check_box_tag :selected, @book.id, @book.selected, id: "book-select_#{@book.id}"  %> <small>Add to selected books</small>
+  <% end %>
 
 <div class="show">
-  <% if librarian_user? %>
-    <%=  check_box_tag :selected, @book.id, @book.selected, id: "book-select_#{@book.id}"  %>
-  <% end %>
   <p>Author(s): </p>
     <ul>
     <% @book.authors.each do |a| %>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -20,13 +20,21 @@
   </fieldset>
 
   <fieldset>
-    <%= f.label :name, "Legal Name" %>
-    <%= f.text_field :name, required: true  %>
+    <%= f.label :password %>
+    <%= f.password_field :password, autocomplete: "off" %>
+    <small>leave blank if you don't want to change it</small>
   </fieldset>
 
   <fieldset>
-    <%= f.label :preferred_first_name %>
-    <%= f.text_field :preferred_first_name  %>
+    <%= f.label :password_confirmation %>
+    <%= f.password_field :password_confirmation, autocomplete: "off" %>
+  </fieldset>
+
+  <br>
+
+  <fieldset>
+    <%= f.label :name, "Full Legal Name" %>
+    <%= f.text_field :name, required: true  %>
   </fieldset>
 
   <fieldset>
@@ -40,15 +48,11 @@
   </fieldset>
 
   <fieldset>
-    <%= f.label :password %>
-    <%= f.password_field :password, autocomplete: "off" %>
-    <small>leave blank if you don't want to change it</small>
+    <%= f.label :preferred_first_name %>
+    <%= f.text_field :preferred_first_name  %>
   </fieldset>
 
-  <fieldset>
-    <%= f.label :password_confirmation %>
-    <%= f.password_field :password_confirmation, autocomplete: "off" %>
-  </fieldset>
+  <br>
 
   <fieldset>
     <%= f.label :current_password %> <small>we need your current password to confirm your changes</small>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -18,13 +18,20 @@
   </fieldset>
 
   <fieldset>
-    <%= f.label :name, "Legal Name" %>
-    <%= f.text_field :name, required: true  %>
+    <%= f.label :password %>
+    <%= f.password_field :password, autocomplete: "off" %>
   </fieldset>
 
   <fieldset>
-    <%= f.label :preferred_first_name %>
-    <%= f.text_field :preferred_first_name  %>
+    <%= f.label :password_confirmation %>
+    <%= f.password_field :password_confirmation, autocomplete: "off" %>
+  </fieldset>
+
+  <br>
+
+  <fieldset>
+    <%= f.label :name, "Full Legal Name" %>
+    <%= f.text_field :name, required: true  %>
   </fieldset>
 
   <fieldset>
@@ -38,13 +45,8 @@
   </fieldset>
 
   <fieldset>
-    <%= f.label :password %>
-    <%= f.password_field :password, autocomplete: "off" %>
-  </fieldset>
-
-  <fieldset>
-    <%= f.label :password_confirmation %>
-    <%= f.password_field :password_confirmation, autocomplete: "off" %>
+    <%= f.label :preferred_first_name %>
+    <%= f.text_field :preferred_first_name  %>
   </fieldset>
 
   <fieldset>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,5 +1,7 @@
 <h2>Sign up</h2>
 
+<p>Create an account to borrow books from the library and view your borrowing history online.</p>
+
 <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
   <%= devise_error_messages! %>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -54,7 +54,7 @@
             <li><%= link_to "logout", destroy_user_session_path, method: :delete %></li>
           <% else %>
             <li><%= link_to "login", new_user_session_path %></li>
-            <li><%= link_to "sign up", new_user_registration_path %></li>
+            <li><%= link_to "create an account", new_user_registration_path %></li>
           <% end %>
 
           </ul>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -28,8 +28,9 @@
       <% end %>
 
       <h2>browse</h2>
-      <h3><%= link_to "by keyword", keywords_path %></h3>
+      <h3><%= link_to "by title", books_path %></h3>
       <h3><%= link_to "by author", authors_path %></h3>
+      <h3><%= link_to "by keyword", keywords_path %></h3>
       <h3><%= link_to "by genre", genres_path %></h3>
     </div>
   </div>

--- a/app/views/search/search.html.erb
+++ b/app/views/search/search.html.erb
@@ -17,7 +17,12 @@
     <div class="search-results">
     <ul>
       <% @books.each do |b| %>
-        <li class="results"><%= link_to b.title, book_path(b.id) %></li>
+        <li class="results">
+        <% if librarian_user? %>
+          <%=  check_box_tag :selected, b.id, b.selected, id: "book-select_#{b.id}"  %>
+        <% end %>
+        <%= link_to b.title, book_path(b.id) %>
+        </li>
       <% end %>
     </ul>
     </div>

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -20,6 +20,10 @@
     <%= u.text_field :notes %>
   </fieldset>
   <fieldset>
+    <%= u.label :identification %>
+    <%= u.text_field :identification %>
+  </fieldset>
+  <fieldset>
     <%= u.label :do_not_lend %>
     <%= u.check_box :do_not_lend %>
   </fieldset>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,6 +1,9 @@
 <h2><%= @user.name %></h2>
 
 <div class="show">
+  <% if librarian_user? && !@user.identification %>
+    <p class= "highlighted_text">PLEASE CHECK AND ENTER USER'S ID NUMBER</p>
+  <% end %>
   <% if current_user == @user %>
     <p><%= link_to "edit login information", edit_user_registration_path, class: "right" %></p>
   <% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -2,7 +2,7 @@
 
 <div class="show">
   <% if librarian_user? && !@user.identification %>
-    <p class= "highlighted_text">PLEASE CHECK AND ENTER USER'S ID NUMBER</p>
+    <p class= "highlighted_text">Before this patron can borrow books, you must check their identification and edit their profile to include it.</p>
   <% end %>
   <% if current_user == @user %>
     <p><%= link_to "edit login information", edit_user_registration_path, class: "right" %></p>


### PR DESCRIPTION
Enforces that librarians must enter patron's identification # before they can borrow; change sign up text; users can enter more of their own info on signup (everyhting except identification #); on edit books, only admins can edit most fields, librarians can only edit keywords; add browse by title (books_path) link to left links
