### PR TITLE
No more nil values in BookAuthors

### DIFF
--- a/app/models/author.rb
+++ b/app/models/author.rb
@@ -1,5 +1,5 @@
 class Author < ActiveRecord::Base
-  has_many :book_authors
+  has_many :book_authors, dependent: :destroy
   has_many :books, through: :book_authors
   has_many :contributions, through: :book_authors
 

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -1,6 +1,6 @@
 class Book < ActiveRecord::Base
 	belongs_to :genre
-  has_many :book_authors
+  has_many :book_authors, dependent: :destroy
   has_many :authors, through: :book_authors
   has_many :book_keywords
   has_many :keywords, through: :book_keywords
@@ -40,7 +40,7 @@ class Book < ActiveRecord::Base
 
     alpha_author = authors.first
 
-    book_authors.each do |b| 
+    book_authors.each do |b|
       return Author.find(b.author_id) if b.primary
       author = Author.find(b.author_id)
       alpha_author = author if author.sort_by < alpha_author.sort_by

--- a/app/models/book_author.rb
+++ b/app/models/book_author.rb
@@ -3,6 +3,8 @@ class BookAuthor < ActiveRecord::Base
   belongs_to :book
   belongs_to :contribution
 
+  validates :author_id, :book_id, presence: true
+
   def self.update_or_delete_from_book(book, book_author_data_by_id)
     if book_author_data_by_id.nil?
       book.book_authors.each { |b| b.delete }

--- a/spec/models/author_spec.rb
+++ b/spec/models/author_spec.rb
@@ -21,6 +21,12 @@ describe Author do
     end
   end
 
+  it "destroys its dependent book_authors on delete" do
+    author = create(:author)
+    BookAuthor.create(book_id: create(:book).id, author_id: (author.id))
+    expect{ author.destroy }.to change{ BookAuthor.count }.by(-1)
+  end
+
   describe "sort_by_name" do
     before do
       @author = FactoryGirl.create(:author, name: "One Two Three")

--- a/spec/models/book_author_spec.rb
+++ b/spec/models/book_author_spec.rb
@@ -17,6 +17,13 @@ describe BookAuthor do
     DatabaseCleaner.clean
   end
 
+  describe "validations" do
+    it "requires author and book to be present" do
+      expect(BookAuthor.new(author_id: @author1.id)).to_not be_valid
+      expect(BookAuthor.new(book_id: @book.id)).to_not be_valid
+    end
+  end
+
   describe "removing book authors" do
     it "removes unwanted single book authors" do
       hash = {"#{@book_author1.id}"=>{"author_id"=>"#{@author1.id}", "contribution_id"=>"", "primary"=>"false"}}
@@ -40,13 +47,27 @@ describe BookAuthor do
     expect(@book_author1.reload.primary).to eq(true)
   end
 
-  describe "adding book authors" do
+  describe "adding multiple book authors" do
     it "creates book authors" do
       author3 = create(:author)
       author4 = create(:author)
-      hash = { "new 557"=>{"author_id"=>"#{author3.id}", "contribution_id"=>"3", "primary"=>"false"},
-               "new 210"=>{"author_id"=>"#{author4.id}", "contribution_id"=>"", "primary"=>"false"} }
+
+      hash = { "new 557"=>{author_id: author3.id, contribution_id: "3", primary: true},
+               "new 210"=>{author_id: author4.id, contribution_id: "", primary: false} }
+
       expect{BookAuthor.create_multi(@book, hash)}.to change{BookAuthor.count}.by(2)
+    end
+
+    it "creates book authors" do
+      author3 = create(:author)
+      author4 = create(:author)
+
+      hash = { "new 55"=>{author_id: author3.id, contribution_id: "3", primary: true}}
+
+      BookAuthor.create_multi(@book, hash)
+
+      ba1 = BookAuthor.last
+      expect(ba1.author_id).to eq(author3.id)
     end
   end
 

--- a/spec/models/book_spec.rb
+++ b/spec/models/book_spec.rb
@@ -37,6 +37,11 @@ describe Book do
     end
   end
 
+  it "destroys its dependent book_authors on delete" do
+    BookAuthor.create(book_id: book.id, author_id: (create(:author).id))
+    expect{ book.destroy }.to change{ BookAuthor.count }.by(-1)
+  end
+
   describe "search" do
     before :all do
       @book1 = FactoryGirl.create(:book, title: "Boogers and Their Uses", isbn: "9988998899" )

--- a/spec/models/contribution_spec.rb
+++ b/spec/models/contribution_spec.rb
@@ -9,14 +9,10 @@ describe Contribution do
     DatabaseCleaner.clean
   end
 
-  let(:contribution) { FactoryGirl.create(:contribution) }
-  let(:author) { FactoryGirl.create(:author) }
-  let(:book) { FactoryGirl.create(:book) }
-  let(:book_author) { FactoryGirl.create(:book_author, author: author, book: book, contribution: contribution)}
-
-  before do
-    contribution.authors << author
-  end
+  let!(:contribution) { FactoryGirl.create(:contribution) }
+  let!(:author) { FactoryGirl.create(:author) }
+  let!(:book) { FactoryGirl.create(:book) }
+  let!(:book_author) { FactoryGirl.create(:book_author, author: author, book: book, contribution: contribution)}
 
   subject { contribution }
 
@@ -25,18 +21,18 @@ describe Contribution do
     it {should respond_to(:authors) }
 
     it "should have authors" do
-      contribution.authors.should_not be_empty
+      expect(contribution.authors).to_not be_empty
     end
 
   end
 
   describe "validations" do
     it "will not create a contribution without a name" do
-      FactoryGirl.build(:contribution, name: "").should_not be_valid
+      expect(FactoryGirl.build(:contribution, name: "")).to_not be_valid
     end
 
     it "will not create a contribution with a duplicate name" do
-      FactoryGirl.build(:contribution, name: contribution.name).should_not be_valid
+      expect(FactoryGirl.build(:contribution, name: contribution.name)).to_not be_valid
     end
   end
 
@@ -47,11 +43,11 @@ describe Contribution do
     describe "should have an association to author" do
 
       it "via contribution" do
-        contribution.authors.should include author
+        expect(contribution.authors).to include(author)
       end
 
       it "via author" do
-        author.contributions.should include contribution
+        expect(author.contributions).to include(contribution)
       end
     end
   end


### PR DESCRIPTION
This responds bug Scott emailed about last week, where book#show wasn't working. A BookAuthor object associated with that book had a nil value for author_id (like, the author was deleted after being added?). 

This change prevents a BookAuthor being created with a nil value, and deletes orphan BookAuthors on delete of a Book or Author. 
