### PR TITLE
Add pagination links to loan list

### DIFF
--- a/app/views/loans/_loan_list.html.erb
+++ b/app/views/loans/_loan_list.html.erb
@@ -1,3 +1,4 @@
+<%= will_paginate @loans %>
 <table class="index">
   <% @librarian_user = librarian_user? %>
   <thead>
@@ -56,3 +57,4 @@
     <% end %>
   </tbody>
 </table>
+<%= will_paginate @loans %>


### PR DESCRIPTION
Fix the bug where user could only see 50 loans at a time. Oops. 
