### PR TITLE
change to new turbolinks syntax for page load

### DIFF
--- a/app/assets/javascripts/reports.js.coffee
+++ b/app/assets/javascripts/reports.js.coffee
@@ -45,4 +45,4 @@ appendDateRanges=()->
   $('#date-range-selector').replaceWith(startDate)
 
 $(document).ready(ready)
-$(document).on('page:load', ready)
+$(document).on('turbolinks:load', ready)

--- a/app/assets/javascripts/shared.js.coffee
+++ b/app/assets/javascripts/shared.js.coffee
@@ -14,4 +14,4 @@ ready = ->
     return
 
 $(document).ready(ready)
-$(document).on('page:load', ready)
+$(document).on('turbolinks:load', ready)


### PR DESCRIPTION
An update to turbolinks has caused `$(document).on('page:load', function)` be become invalid. This changes the syntax to match the new turbolinks syntax.